### PR TITLE
Added mute/unmute features.

### DIFF
--- a/mpyg321/mpyg321.py
+++ b/mpyg321/mpyg321.py
@@ -289,6 +289,10 @@ class MPyg321Player:
         if self.player_version == "mpg321":
             self.player.sendline("GAIN {}".format(percent))
 
+    def mute(self):
+        """Mutes the player"""
+        self.player.sendline("MUTE")
+
     def silence_mpyg_output(self):
         """Improves performance by silencing the mpg123 process frame output"""
         if self.player_version == "mpg123" and not self.performance_mode:

--- a/mpyg321/mpyg321.py
+++ b/mpyg321/mpyg321.py
@@ -57,6 +57,16 @@ mpg_outs = [
         "action": None,
         "description": "Timeout event."
     },
+    {
+        "mpg_code": "@mute",
+        "action": "on_user_mute",
+        "description": "Player has been muted by the user."
+    },
+    {
+        "mpg_code": "@unmute",
+        "action": "on_user_unmute",
+        "description": "Player has been unmuted by the user."
+    },
 ]
 
 mpg_codes = [v["mpg_code"] for v in mpg_outs]

--- a/mpyg321/mpyg321.py
+++ b/mpyg321/mpyg321.py
@@ -59,12 +59,12 @@ mpg_outs = [
     },
     {
         "mpg_code": "@mute",
-        "action": "on_user_mute",
+        "action": "user_mute",
         "description": "Player has been muted by the user."
     },
     {
         "mpg_code": "@unmute",
-        "action": "on_user_unmute",
+        "action": "user_unmute",
         "description": "Player has been unmuted by the user."
     },
 ]
@@ -249,6 +249,10 @@ class MPyg321Player:
                 self.on_user_start_or_resume_int()
             if action == "end_of_song":
                 self.on_end_of_song_int()
+            if action == "user_mute":
+                self.on_user_mute()
+            if action == "user_unmute":
+                self.on_user_unmute()
             if action == "error":
                 self.on_error()
 

--- a/mpyg321/mpyg321.py
+++ b/mpyg321/mpyg321.py
@@ -400,6 +400,14 @@ class MPyg321Player:
         """Callback when user stops music"""
         pass
 
+    def on_user_mute(self):
+        """Callback when user mutes player"""
+        pass
+
+    def on_user_unmute(self):
+        """Callback when user unmutes player"""
+        pass
+
     def on_music_end(self):
         """Callback when music ends"""
         pass

--- a/mpyg321/mpyg321.py
+++ b/mpyg321/mpyg321.py
@@ -291,11 +291,13 @@ class MPyg321Player:
 
     def mute(self):
         """Mutes the player"""
-        self.player.sendline("MUTE")
+        if self.player_version == "mpg123":
+            self.player.sendline("MUTE")
 
     def unmute(self):
         """Unmutes the player"""
-        self.player.sendline("UNMUTE")
+        if self.player_version == "mpg123":
+            self.player.sendline("UNMUTE")
 
     def silence_mpyg_output(self):
         """Improves performance by silencing the mpg123 process frame output"""

--- a/mpyg321/mpyg321.py
+++ b/mpyg321/mpyg321.py
@@ -293,6 +293,10 @@ class MPyg321Player:
         """Mutes the player"""
         self.player.sendline("MUTE")
 
+    def unmute(self):
+        """Unmutes the player"""
+        self.player.sendline("UNMUTE")
+
     def silence_mpyg_output(self):
         """Improves performance by silencing the mpg123 process frame output"""
         if self.player_version == "mpg123" and not self.performance_mode:


### PR DESCRIPTION
I've added mute and unmute features to `mpyg321.py`. These include:
- Actual functions for muting/unmuting.
- Callbacks when the user mutes/unmutes the player (I'm actually not sure where these are called so I've only added the skeleton functions).
- Dictionary entries for `mpg_outs`.

Some things to note: `mpg123` does have a mute/unmute feature, but `mpg321` does not. I've implemented a simple if-statement to check if the player is `mpg123` and if so, perform the mute/unmute. If you'd like, I can change it to throw an exception? Also I don't know where the callbacks are actually...called? So I might need to add something else to make sure it is properly implemented.

Fixes: #20 . :D