### PR TITLE
Implemented BasePlayer class

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -2,8 +2,11 @@
 MPyG321 basic example
 Playing and pausing some music
 You need to add a "sample.mp3" file in the working directory
+
+In this example, you can replace MPyg321Player by MPyg123Player
+according to the player you installed on your machine (mpg321/mpg123)
 """
-from mpyg321.mpyg321 import MPyg321Player
+from mpyg321.MPyg321Player import MPyg321Player
 from time import sleep
 
 

--- a/examples/callbacks.py
+++ b/examples/callbacks.py
@@ -1,9 +1,12 @@
 """
-MPyG321 callbacks example
+MPyg321 callbacks example
 Playing and pausing some music, triggering callbacks
 You need to add a "sample.mp3" file in the working directory
+
+In this example, you can replace MPyg321Player by MPyg123Player
+according to the player you installed on your machine (mpg321/mpg123)
 """
-from mpyg321.mpyg321 import MPyg321Player
+from mpyg321.MPyg321Player import MPyg321Player
 from time import sleep
 
 
@@ -40,6 +43,9 @@ def do_some_play_pause(player):
     player.resume()
     sleep(5)
     player.stop()
+    sleep(2)
+    player.play()
+    sleep(20)
     player.quit()
 
 

--- a/mpyg321/BasePlayer.py
+++ b/mpyg321/BasePlayer.py
@@ -1,0 +1,203 @@
+"""
+Mpyg BasePlayer base class
+This class contains all the functions that are common
+both to mpg321 and mpg123.
+All the players implement this base class and add their
+specific feature.
+"""
+import pexpect
+from threading import Thread
+from MpygError import *
+from consts import *
+
+
+class BasePlayer:
+    """Base class for players"""
+    player = None
+    status = None
+    output_processor = None
+    song_path = ""
+    loop = False
+    performance_mode = True
+    suitable_versions = []
+    default_player = ""
+
+    def __init__(self, player=None, audiodevice=None, performance_mode=True):
+        """Builds the player and creates the callbacks"""
+        self.set_player(player, audiodevice)
+        self.output_processor = Thread(target=self.process_output)
+        self.output_processor.daemon = True
+        self.performance_mode = performance_mode
+        self.output_processor.start()
+
+    def check_player(self, player):
+        """Gets the player """
+        version_process = None
+        if player is None:
+            player = self.default_player
+        try:
+            cmd = str(player) + " --version"
+            version_process = pexpect.spawn(cmd, timeout=5)
+            version_process.expect(self.suitable_versions)
+        except pexpect.exceptions.ExceptionPexpect:
+            raise MPygPlayerNotFoundError(
+                """No suitable player found""")
+
+    def set_player(self, player, audiodevice):
+        """Sets the player"""
+        self.check_player(player)
+        args = " --audiodevice " + audiodevice if audiodevice else ""
+        args += "-R mpyg"
+        self.player = pexpect.spawn(str(player) + " " + args)
+        self.player.delaybeforesend = None
+        self.status = PlayerStatus.INSTANCIATED
+
+    def process_output(self):
+        """Parses the output"""
+        while True:
+            index = self.player.expect(mpg_codes)
+            action = mpg_outs[index]["action"]
+            if action == "music_stop":
+                self.on_music_stop_int()
+            if action == "user_pause":
+                self.on_user_pause_int()
+            if action == "user_start_or_resume":
+                self.on_user_start_or_resume_int()
+            if action == "end_of_song":
+                self.on_end_of_song_int()
+            if action == "user_mute":
+                self.on_user_mute()
+            if action == "user_unmute":
+                self.on_user_unmute()
+            if action == "error":
+                self.on_error()
+
+    def play_song(self, path, loop=False):
+        """Plays the song"""
+        self.loop = loop
+        self.set_song(path)
+        self.play()
+
+    def play(self):
+        """Starts playing the song"""
+        self.player.sendline("LOAD " + self.song_path)
+        self.status = PlayerStatus.PLAYING
+
+    def pause(self):
+        """Pauses the player"""
+        if self.status == PlayerStatus.PLAYING:
+            self.player.sendline("PAUSE")
+            self.status = PlayerStatus.PAUSED
+
+    def resume(self):
+        """Resume the player"""
+        if self.status == PlayerStatus.PAUSED:
+            self.player.sendline("PAUSE")
+            self.on_user_resume()
+
+    def stop(self):
+        """Stops the player"""
+        self.player.sendline("STOP")
+        self.status = PlayerStatus.STOPPING
+
+    def quit(self):
+        """Quits the player"""
+        self.player.sendline("QUIT")
+        self.status = PlayerStatus.QUITTED
+
+    def jump(self, pos):
+        """Jump to position"""
+        self.player.sendline("JUMP " + str(pos))
+
+    def on_error(self):
+        """Process errors encountered by the player"""
+        output = self.player.readline().decode("utf-8")
+
+        # Check error in list of errors
+        for mpg_error in mpg_errors:
+            if mpg_error["message"] in output:
+                action = mpg_error["action"]
+                if action == "generic_error":
+                    raise MPygError(output)
+                if action == "file_error":
+                    raise MPygFileError(output)
+                if action == "command_error":
+                    raise MPygCommandError(output)
+                if action == "argument_error":
+                    raise MPygArgumentError(output)
+                if action == "eq_error":
+                    raise MPygEQError
+                if action == "seek_error":
+                    raise MPygSeekError
+
+        # Some other error occurred
+        raise MPygError(output)
+
+    def set_song(self, path):
+        """song_path setter"""
+        self.song_path = path
+
+    def set_loop(self, loop):
+        """"loop setter"""
+        self.loop = loop
+
+    # # # Internal Callbacks # # #
+    def on_music_stop_int(self):
+        """Internal callback when the music is stopped"""
+        if self.status == PlayerStatus.STOPPING:
+            self.on_user_stop_int()
+            self.status = PlayerStatus.STOPPED
+        else:
+            self.on_end_of_song_int()
+
+    def on_user_stop_int(self):
+        """Internal callback when the user stops the music."""
+        self.on_any_stop()
+        self.on_user_stop()
+
+    def on_user_pause_int(self):
+        """Internal callback when user pauses the music"""
+        self.on_any_stop()
+        self.on_user_pause()
+
+    def on_user_start_or_resume_int(self):
+        """Internal callback when user resumes the music"""
+        self.status = PlayerStatus.PLAYING
+
+    def on_end_of_song_int(self):
+        """Internal callback when the song ends"""
+        if(self.loop):
+            self.play()
+        else:
+            # The music doesn't stop if it is looped
+            self.on_any_stop()
+        self.on_music_end()
+
+    # # # Public Callbacks # # #
+    def on_any_stop(self):
+        """Callback when the music stops for any reason"""
+        pass
+
+    def on_user_pause(self):
+        """Callback when user pauses the music"""
+        pass
+
+    def on_user_resume(self):
+        """Callback when user resumes the music"""
+        pass
+
+    def on_user_stop(self):
+        """Callback when user stops music"""
+        pass
+
+    def on_user_mute(self):
+        """Callback when user mutes player"""
+        pass
+
+    def on_user_unmute(self):
+        """Callback when user unmutes player"""
+        pass
+
+    def on_music_end(self):
+        """Callback when music ends"""
+        pass

--- a/mpyg321/BasePlayer.py
+++ b/mpyg321/BasePlayer.py
@@ -78,10 +78,6 @@ player (Mpyg321Player or Mpyg123Player)""")
                 self.on_user_start_or_resume_int()
             elif action == "end_of_song":
                 self.on_end_of_song_int()
-            elif action == "user_mute":
-                self.on_user_mute()
-            elif action == "user_unmute":
-                self.on_user_unmute()
             elif action == "error":
                 self.on_error()
             else:

--- a/mpyg321/MPyg321Player.py
+++ b/mpyg321/MPyg321Player.py
@@ -1,0 +1,19 @@
+from email.mime import audio
+from .BasePlayer import BasePlayer
+
+
+class MPyg321Player(BasePlayer):
+    """Player for legacy mpg321"""
+    def __init__(self, player=None, audiodevice=None, performance_mode=True):
+        self.suitable_versions = ["mpg321"]
+        self.default_player = "mpg321"
+        super().__init__(player, audiodevice, performance_mode)
+
+    def output_process_ext(self, action):
+        """
+        Processes specific output for mpg321 player
+        It should contain the code for the mpg_out "end_of_song"
+        We did not put it because the BaseClass implements a behavior
+        which works for both versions
+        """
+        pass

--- a/mpyg321/MPyg321Player.py
+++ b/mpyg321/MPyg321Player.py
@@ -1,4 +1,3 @@
-from email.mime import audio
 from .BasePlayer import BasePlayer
 
 

--- a/mpyg321/MpygError.py
+++ b/mpyg321/MpygError.py
@@ -1,0 +1,34 @@
+# # # Errors # # #
+class MPygError(RuntimeError):
+    """Base class for any errors encountered by the player during runtime"""
+    pass
+
+
+class MPygFileError(MPygError):
+    """Errors encountered by the player related to files"""
+    pass
+
+
+class MPygCommandError(MPygError):
+    """Errors encountered by the player related to player commands"""
+    pass
+
+
+class MPygArgumentError(MPygError):
+    """Errors encountered by the player related to arguments for commands"""
+    pass
+
+
+class MPygEQError(MPygError):
+    """Errors encountered by the player related to the equalizer"""
+    pass
+
+
+class MPygSeekError(MPygError):
+    """Errors encountered by the player related to the seek"""
+    pass
+
+
+class MPygPlayerNotFoundError(MPygError):
+    """Errors encountered when no suitable player is found"""
+    pass

--- a/mpyg321/consts.py
+++ b/mpyg321/consts.py
@@ -1,0 +1,127 @@
+from pexpect import TIMEOUT as pexpectTIMEOUT
+mpg_outs = [
+    {
+        "mpg_code": "@P 0",
+        "action": "music_stop",
+        "description": """For mpg123, it corresponds to any stop
+                        For mpg312 it corresponds to user stop only"""
+    },
+    {
+        "mpg_code": "@P 1",
+        "action": "user_pause",
+        "description": "Music has been paused by the user."
+    },
+    {
+        "mpg_code": "@P 2",
+        "action": "user_start_or_resume",
+        "description": "Music has been started resumed by the user."
+    },
+    {
+        "mpg_code": "@P 3",
+        "action": "end_of_song",
+        "description": "Player has reached the end of the song."
+    },
+    {
+        "mpg_code": "@E *",
+        "action": "error",
+        "description": "Player has encountered an error."
+    },
+    {
+        "mpg_code": "@silence",
+        "action": None,
+        "description": "Player has been silenced by the user."
+    },
+    {
+        "mpg_code": r"@V [0-9\.\s%]*",
+        "action": None,
+        "description": "Volume change event.",
+    },
+    {
+        "mpg_code": r"@S [a-zA-Z0-9\.\s-]*",
+        "action": None,
+        "description": "Stereo info event."
+    },
+    {
+        "mpg_code": "@I *",
+        "action": None,
+        "description": "Information event."
+    },
+    {
+        "mpg_code": pexpectTIMEOUT,
+        "action": None,
+        "description": "Timeout event."
+    },
+    {
+        "mpg_code": "@mute",
+        "action": "user_mute",
+        "description": "Player has been muted by the user."
+    },
+    {
+        "mpg_code": "@unmute",
+        "action": "user_unmute",
+        "description": "Player has been unmuted by the user."
+    },
+]
+
+mpg_codes = [v["mpg_code"] for v in mpg_outs]
+
+mpg_errors = [
+    {
+        "message": "empty list name",
+        "action": "generic_error"
+    },
+    {
+        "message": "No track loaded!",
+        "action": "generic_error"
+    },
+    {
+        "message": "Error opening stream",
+        "action": "file_error"
+    },
+    {
+        "message": "failed to parse given eq file:",
+        "action": "file_error"
+    },
+    {
+        "message": "Corrupted file:",
+        "action": "file_error"
+    },
+    {
+        "message": "Unknown command:",
+        "action": "command_error"
+    },
+    {
+        "message": "Unfinished command:",
+        "action": "command_error"
+    },
+    {
+        "message": "Unknown command or no arguments:",
+        "action": "argument_error"
+    },
+    {
+        "message": "invalid arguments for",
+        "action": "argument_error"
+    },
+    {
+        "message": "Missing argument to",
+        "action": "argument_error"
+    },
+    {
+        "message": "failed to set eq:",
+        "action": "eq_error"
+    },
+    {
+        "message": "Error while seeking",
+        "action": "seek_error"
+    },
+]
+
+
+class PlayerStatus:
+    INSTANCIATED = 0
+    PLAYING = 1
+    PAUSED = 2
+    RESUMING = 3
+    STOPPING = 4
+    STOPPED = 5
+    QUITTED = 6

--- a/mpyg321/consts.py
+++ b/mpyg321/consts.py
@@ -17,11 +17,6 @@ mpg_outs = [
         "description": "Music has been started resumed by the user."
     },
     {
-        "mpg_code": "@P 3",
-        "action": "end_of_song",
-        "description": "Player has reached the end of the song."
-    },
-    {
         "mpg_code": "@E *",
         "action": "error",
         "description": "Player has encountered an error."
@@ -50,20 +45,30 @@ mpg_outs = [
         "mpg_code": pexpectTIMEOUT,
         "action": None,
         "description": "Timeout event."
-    },
-    {
-        "mpg_code": "@mute",
-        "action": "user_mute",
-        "description": "Player has been muted by the user."
-    },
-    {
-        "mpg_code": "@unmute",
-        "action": "user_unmute",
-        "description": "Player has been unmuted by the user."
-    },
+    }
 ]
 
-mpg_codes = [v["mpg_code"] for v in mpg_outs]
+mpg_outs_ext = {
+    "mpg123": [
+        {
+            "mpg_code": "@mute",
+            "action": "user_mute",
+            "description": "Player has been muted by the user."
+        },
+        {
+            "mpg_code": "@unmute",
+            "action": "user_unmute",
+            "description": "Player has been unmuted by the user."
+        }
+    ],
+    "mpg321": [
+        {
+            "mpg_code": "@P 3",
+            "action": "end_of_song",
+            "description": "Player has reached the end of the song."
+        }
+    ]
+}
 
 mpg_errors = [
     {


### PR DESCRIPTION
There we go for the BasePlayer class.

I took a lot of the code from the previous MPyg321 class and tried to make an abstract version of anything that could have create a conflict. I also put most of the constants and external classes in external files for clarity.

The main issues that we might find:
- I use a global value for `mpg_outs` and `mpg_codes`. This means that `pexpect` will look for codes that are not supposed to happen in the used version (codes from mpg321 when using mpg123 and codes from mpg123 when using mpg321). I made it for simplicity, and this should not be an issue for now but might be one in the future. 

One of the things that annoys me the most here is the "end_of_song" callback. With mpg321, we have an explicit code for end of song (@P 3) while mpg123 doesn't have any (so I basically implement it in a weird way by using the status `PlayerStatus.STOPPING` value in order to let the class know that it is a user stop and not the end of the song).

Another thing that could be annoying here is the fact that the class is ready to call for `on_user_mute`/`on_user_unmute` while it doesn't make sense for mpg321.

An easy fix would be to implement the process_output class in the subclasses instead of the main one... But this is such a central class that I find it a bit sad. What do you guys think?

- Another thing that is annoying is the "-R mpyg" argument. When using mpg123, it seams that the "mpyg" part of the argument makes it impossible to add other arguments after it. This is the reason why I inverted the `--audiodevice` and the `-R` args so that it works (I haven't tested it though, so it is worth testing).

Same problem here, if we want to implement it in the cleanest way, we should externalize this very central part of the code.

Waiting for your comments :) 